### PR TITLE
Apollo 2.0.5 + default_group + fixes

### DIFF
--- a/create_or_update_organism.py
+++ b/create_or_update_organism.py
@@ -9,7 +9,7 @@ log = logging.getLogger(__name__)
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Sample script to add an attribute to a feature via web services')
+    parser = argparse.ArgumentParser(description='Create or update an organism in an Apollo instance')
     WAAuth(parser)
 
     parser.add_argument('jbrowse', help='JBrowse Data Directory')
@@ -18,6 +18,7 @@ if __name__ == '__main__':
     parser.add_argument('--genus', help='Organism Genus')
     parser.add_argument('--species', help='Organism Species')
     parser.add_argument('--public', action='store_true', help='Make organism public')
+    parser.add_argument('--group', help='Give access to a user group')
 
     args = parser.parse_args()
     wa = WebApolloInstance(args.apollo, args.username, args.password)
@@ -67,6 +68,13 @@ if __name__ == '__main__':
             export=True,
             read=True,
         )
+
+        # Group access
+        if args.group:
+            group = wa.groups.loadGroupByName(name=args.group)
+            res = wa.groups.updateOrganismPermission(group, org_cn,
+                                             administrate=False, write=True, read=True,
+                                             export=True)
 
     data = [o for o in data if o['commonName'] == org_cn]
     print json.dumps(data, indent=2)

--- a/create_or_update_organism.xml
+++ b/create_or_update_organism.xml
@@ -15,7 +15,11 @@ python $__tool_directory__/create_or_update_organism.py
 
 --genus "$genus"
 --species "$species"
-$public
+#if $perms.public == "yes":
+    --public
+#else if $perms.group:
+    --group '${perms.group}'
+#end if
 
 @ORG_OR_GUESS@
 
@@ -29,7 +33,16 @@ $__user_email__
     <expand macro="org_or_guess" />
     <param name="genus" type="text" label="Genus" optional="False" />
     <param name="species" type="text" label="Species" optional="True" />
-    <param name="public" type="boolean" truevalue="--public" falsevalue="" label="Is Organism Public" />
+    <conditional name="perms">
+        <param name="public" type="select" label="Is Organism Public">
+            <option value="no" selected="true">No</option>
+            <option value="yes">Yes</option>
+        </param>
+        <when value="yes"/>
+        <when value="no">
+            <param name="group" type="text" label="Grant access to a user group" optional="True" />
+        </when>
+    </conditional>
   </inputs>
   <outputs>
     <data format="json" name="output"/>

--- a/list_organisms.py
+++ b/list_organisms.py
@@ -4,7 +4,7 @@ import argparse
 from webapollo import WAAuth, WebApolloInstance, AssertUser, accessible_organisms
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='Sample script to add an attribute to a feature via web services')
+    parser = argparse.ArgumentParser(description='List all organisms available in an Apollo instance')
     WAAuth(parser)
     parser.add_argument('email', help='User Email')
     args = parser.parse_args()

--- a/macros.xml
+++ b/macros.xml
@@ -5,6 +5,7 @@
       <requirement type="package" version="2.7">python</requirement>
       <requirement type="package" version="1.65">biopython</requirement>
       <requirement type="package" version="0.6.2">bcbiogff</requirement>
+      <requirement type="package" version="2.12.4">requests</requirement>
       <yield/>
     </requirements>
   </xml>


### PR DESCRIPTION
Hellon
Several changes in this PR:
- added support for tokens to make it work with Apollo 2.0.5
- now it's possible to grant permissions to a group while createing/updating an organism
- working with conda resolver now (still need python modules in .venv for dynamic select boxes)
As usual, comments welcome :)